### PR TITLE
Remove friendly_load tag

### DIFF
--- a/suit_guardian/templates/admin/guardian/model/obj_perms_manage.html
+++ b/suit_guardian/templates/admin/guardian/model/obj_perms_manage.html
@@ -1,7 +1,6 @@
 {% extends "admin/change_form.html" %}
 {% load i18n %}
 {% load guardian_tags %}
-{% friendly_load adminmedia %}
 
 {% if not is_popup %}
     {% block breadcrumbs %}


### PR DESCRIPTION
In django-guardian==1.3.2 friendly_load tag was removed:
https://github.com/django-guardian/django-guardian/commit/30dc72c5d2b2cf90b9ece54c90ac640d6e13a300
